### PR TITLE
(Hide Your Mess Behind) libvips dependency issue

### DIFF
--- a/demos/hide_your_mess_behind_demo/README.md
+++ b/demos/hide_your_mess_behind_demo/README.md
@@ -17,6 +17,11 @@ Download installers of the compiled app. They are available for Windows and Linu
 | Linux | [DEB](https://github.com/openvinotoolkit/openvino_build_deploy/releases/download/hide_your_mess_behind_v1.1/hide-your-mess-behind_1.1.0_amd64.deb) [RPM](https://github.com/openvinotoolkit/openvino_build_deploy/releases/download/hide_your_mess_behind_v1.1/hide-your-mess-behind-1.1.0.x86_64.rpm) |
 | Windows | [EXE](https://github.com/openvinotoolkit/openvino_build_deploy/releases/download/hide_your_mess_behind_v1.1/hide-your-mess-behind.Setup.1.1.0.exe) |
 
+### Ubuntu
+
+```bash
+sudo dpkg -i hide-your-mess-behind_1.1.0_amd64.deb
+```
 
 ## Running the demo using source code and NodeJS
 

--- a/demos/hide_your_mess_behind_demo/README.md
+++ b/demos/hide_your_mess_behind_demo/README.md
@@ -21,6 +21,7 @@ Download installers of the compiled app. They are available for Windows and Linu
 
 ```bash
 sudo dpkg -i hide-your-mess-behind_1.1.0_amd64.deb
+hide-your-mess-behind
 ```
 
 ## Running the demo using source code and NodeJS

--- a/demos/hide_your_mess_behind_demo/package.json
+++ b/demos/hide_your_mess_behind_demo/package.json
@@ -7,6 +7,16 @@
     "dist": "electron-builder"
   },
   "build": {
+    "extraFiles": [
+      {
+        "from": "/usr/lib/x86_64-linux-gnu/libvips-cpp.so.42",
+        "to": "./libvips-cpp.so.42"
+      },
+      {
+        "from": "/usr/lib/x86_64-linux-gnu/libvips.so.42",
+        "to": "./libvips.so.42"
+      }
+    ],
     "appId": "com.example.hideyourmessbehind",
     "mac": {
       "icon": "assets/icons/icon.png"
@@ -18,7 +28,6 @@
     "linux": {
       "target": [
         "deb",
-        "rpm",
         "zip"
       ],
       "icon": "assets/icons/icon.png",
@@ -42,17 +51,15 @@
     "electron-builder": "^25.0.5"
   },
   "dependencies": {
+    "@napi-rs/canvas": "^0.1.52",
     "buffer": "^6.0.3",
     "openvino-node": "2024.3.0",
-    "sharp": "^0.33.5",
-    "@napi-rs/canvas": "^0.1.52"
+    "sharp": "^0.33.5"
   },
   "keywords": [],
   "author": "Mikołaj Roszczyk <mikolaj.roszczyk@intel.com>",
   "contributors": [
-    {
-      "name": "Adrian Boguszewski"
-    }
+    "Adrian Boguszewski"
   ],
   "homepage": "https://github.com/openvinotoolkit/openvino_build_deploy",
   "license": "Apache-2.0",

--- a/demos/hide_your_mess_behind_demo/package.json
+++ b/demos/hide_your_mess_behind_demo/package.json
@@ -33,6 +33,11 @@
       "icon": "assets/icons/icon.png",
       "category": "Utility"
     },
+    "deb": {
+      "depends": [
+        "libvips42"
+      ]
+    },
     "files": [
       "src/**/*.js",
       "src/index.html",


### PR DESCRIPTION
I added two solutions for this issue:

1. To distribute a functional binary (.deb) make sure to have "libvips42" install on the host before creating the .deb file:
Steps:
```
sudo apt install libvips42
npm init -y
npm install
npm run dist
```
Now, make sure you uninstall libvips42 to test the .deb which includes the .so libraries:
```
sudo apt remove libvips42
sudo dpkg -i dist/hide-your-mess-behind_1.1.0_amd64.deb
hide-your-mess-behind
```

2. The second approach is to prompt the user a message to install dependencies after running dpkg.
```
(Reading database ... 411173 files and directories currently installed.)
Preparing to unpack .../hide-your-mess-behind_1.1.0_amd64.deb ...
Unpacking hide-your-mess-behind (1.1.0) over (1.1.0) ...
dpkg: dependency problems prevent configuration of hide-your-mess-behind:
 hide-your-mess-behind depends on libvips42; however:
  Package libvips42 is not installed.

dpkg: error processing package hide-your-mess-behind (--install):
 dependency problems - leaving unconfigured
Processing triggers for mailcap (3.70+nmu1ubuntu1) ...
Processing triggers for gnome-menus (3.36.0-1ubuntu3) ...
Processing triggers for desktop-file-utils (0.26-1ubuntu3) ...
Processing triggers for hicolor-icon-theme (0.17-2) ...
Errors were encountered while processing:
 hide-your-mess-behind
```

Simply run `sudo apt install -f`

This second approach is in case the .so libraries were not included in the .deb

Fixes #108 