### PR TITLE
Update requirements.txt to support Python3.12 and correct the onnxruntime version to fix the DLL error issue

### DIFF
--- a/notebooks/onnxruntime_lcm/requirements.txt
+++ b/notebooks/onnxruntime_lcm/requirements.txt
@@ -3,12 +3,12 @@
 jupyterlab==4.2.5
 ipywidgets==8.1.5
 
-openvino==2024.3.0
-onnx==1.17.0
-onnxruntime-openvino==1.19.0
+openvino==2024.4.0
+onnx==1.16.1
+onnxruntime-openvino==1.20.0
 optimum==1.19.1
 accelerate==0.33.0
-optimum-intel==1.16.1
+optimum-intel==1.19.0
 diffusers==0.27.2
 numpy==1.26.4
 huggingface_hub==0.25.0


### PR DESCRIPTION
https://jira.devtools.intel.com/browse/OWR-59694

[AIPCDevKit]Need to correct onnxruntime version to 1.20.0 in requirements.txt in openvino_build_deploy/notebooks/onnxruntime repos and also getting DLL error while loading model with python3.12 version

The onnx 16.1 downgrade is required as per https://github.com/onnx/onnx/issues/6267.
The other module upgrades are required for using Python3.12 version and openvino 2024.4 version.