### PR TITLE
feat: replace FAISS with LlamaIndex default vector store

### DIFF
--- a/ai_ref_kits/conversational_ai_chatbot/app.py
+++ b/ai_ref_kits/conversational_ai_chatbot/app.py
@@ -15,7 +15,7 @@ import torch
 import yaml
 import nltk
 from langchain_text_splitters import RecursiveCharacterTextSplitter
-from llama_index.core import Document, VectorStoreIndex, Settings, StorageContext
+from llama_index.core import Document, VectorStoreIndex, Settings
 from llama_index.core.chat_engine import SimpleChatEngine
 from llama_index.core.chat_engine.types import BaseChatEngine, ChatMode
 from llama_index.core.memory import ChatMemoryBuffer
@@ -23,12 +23,9 @@ from llama_index.core.node_parser import LangchainNodeParser
 from llama_index.embeddings.huggingface_openvino import OpenVINOEmbedding
 from llama_index.llms.openvino import OpenVINOLLM
 from llama_index.postprocessor.openvino_rerank import OpenVINORerank
-from llama_index.vector_stores.faiss import FaissVectorStore
 from optimum.intel import OVModelForSpeechSeq2Seq
 from transformers import AutoProcessor, TextIteratorStreamer
 from melo.api import TTS
-# it must be imported as the last one; otherwise, it causes a crash on macOS
-import faiss
 
 # Global variables initialization
 TARGET_AUDIO_SAMPLE_RATE = 16000
@@ -217,38 +214,47 @@ def load_file(file_path: Path) -> Document:
 def load_context(file_path: Path) -> None:
     """
     Load context (document) and create a RAG pipeline
-
     Params:
         file_path: the path to the document
     """
     global ov_chat_engine
 
-    # limit chat history
+    # Create memory buffer for chat history
     memory = ChatMemoryBuffer.from_defaults()
 
-    # when context removed, no longer RAG pipeline is needed
+    # if no file is provided, use the default chat engine (not RAG based)
     if not file_path:
-        ov_chat_engine = SimpleChatEngine.from_defaults(llm=ov_llm, system_prompt=chatbot_config["system_configuration"], memory=memory)
+        ov_chat_engine = SimpleChatEngine.from_defaults(
+            llm=ov_llm,
+            system_prompt=chatbot_config["system_configuration"],
+            memory=memory
+        )
         return
 
+    # load the document
     document = load_file(file_path)
 
-    # a splitter to divide document into chunks
+    # create a splitter to split the document into chunks
     splitter = LangchainNodeParser(RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=100))
 
-    dim = ov_embedding._model.request.outputs[0].get_partial_shape()[2].get_length()
-    # a memory database to store chunks
-    faiss_index = faiss.IndexFlatL2(dim)
-    vector_store = FaissVectorStore(faiss_index=faiss_index)
-    storage_context = StorageContext.from_defaults(vector_store=vector_store)
-
-    # set embedding model
+    # set the embedding model
     Settings.embed_model = ov_embedding
-    index = VectorStoreIndex.from_documents([document], storage_context, transformations=[splitter])
-    # create a RAG pipeline
-    ov_chat_engine = index.as_chat_engine(llm=ov_llm, chat_mode=ChatMode.CONTEXT, system_prompt=chatbot_config["system_configuration"],
-                                          memory=memory, node_postprocessors=[ov_reranker])
+    
+    # Create index using LlamaIndex's default vector store (in-memory) and the splitter
+    index = VectorStoreIndex.from_documents(
+        [document], 
+        transformations=[splitter], 
+        embed_model=ov_embedding
+    )
 
+    # Build RAG chat engine with reranker and memory
+    ov_chat_engine = index.as_chat_engine(
+        llm=ov_llm,
+        chat_mode=ChatMode.CONTEXT,
+        system_prompt=chatbot_config["system_configuration"],
+        memory=memory,
+        node_postprocessors=[ov_reranker]
+    )
 
 def generate_initial_greeting() -> str:
     """

--- a/ai_ref_kits/conversational_ai_chatbot/requirements.txt
+++ b/ai_ref_kits/conversational_ai_chatbot/requirements.txt
@@ -1,17 +1,14 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 
-openvino==2025.1
-optimum-intel==1.23.0
-optimum==1.25.3
-nncf==2.16.0
+openvino==2025.2
+optimum-intel==1.24.0
+nncf==2.17.0
 
 llama-index==0.12.28
 llama-index-llms-openvino==0.4.0
 llama-index-embeddings-openvino==0.5.1
 llama-index-postprocessor-openvino-rerank==0.4.1
-llama-index-vector-stores-faiss==0.3.0
 langchain-text-splitters==0.3.4
-faiss-cpu==1.11.0
 
 onnx==1.18.0
 onnxruntime==1.20.1


### PR DESCRIPTION
This PR simplifies the conversational AI chatbot implementation by replacing the explicit use of the FAISS vector database with LlamaIndex's default in-memory vector store and also updates on requirements.txt