### PR TITLE
Update OpenVINO to v2025.2 and add MacOS installation instructions

### DIFF
--- a/ai_ref_kits/agentic_llm_rag/README.md
+++ b/ai_ref_kits/agentic_llm_rag/README.md
@@ -48,8 +48,14 @@ This project requires Python 3.10 or higher and a few libraries. If you don't al
 
 To install the Python libraries and tools, run this command:
 
+**For Linux users**
 ```shell
 sudo apt install git gcc python3-venv python3-dev
+```
+
+**For MacOS users**
+```shell
+brew install git gcc
 ```
 
 _NOTE: If you are using Windows, you might also have to install [Microsoft Visual C++ Redistributable](https://aka.ms/vs/16/release/vc_redist.x64.exe)._

--- a/ai_ref_kits/agentic_llm_rag/requirements.txt
+++ b/ai_ref_kits/agentic_llm_rag/requirements.txt
@@ -1,6 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 
-openvino==2025.1
+openvino==2025.2
 optimum-intel==1.23.0
 optimum==1.25.3
 nncf==2.16.0


### PR DESCRIPTION
- Updated OpenVINO version from 2025.1 to 2025.2 in requirements.txt
- Added MacOS installation instructions using brew in README.md