### PR TITLE
Removed --token flag from huggingface-cli login 

### DIFF
--- a/.github/reusable-steps/setup-hugging-face/action.yml
+++ b/.github/reusable-steps/setup-hugging-face/action.yml
@@ -19,7 +19,7 @@ runs:
       run: |
         if [ -n "$HF_TOKEN" ]; then  
           export PYTHONIOENCODING=utf-8
-          huggingface-cli login --token "$HF_TOKEN"
+          huggingface-cli login
         else
           echo "HF_TOKEN not set, continuing without login."
         fi


### PR DESCRIPTION
Prevent HF_TOKEN exposure in process listings and shell history