### PR TITLE
fix(security)

### DIFF
--- a/ai_ref_kits/agentic_multimodal_travel_planer/start_agents.py
+++ b/ai_ref_kits/agentic_multimodal_travel_planer/start_agents.py
@@ -4,7 +4,7 @@ This module manages the lifecycle of multiple agents, starting worker agents
 before the supervisor agent to ensure proper dependency initialization.
 """
 import os
-import subprocess
+import subprocess  # nosec B404 - controlled argv lists, no shell=True usage
 import sys
 import time
 from pathlib import Path

--- a/ai_ref_kits/agentic_multimodal_travel_planer/utils/util.py
+++ b/ai_ref_kits/agentic_multimodal_travel_planer/utils/util.py
@@ -6,7 +6,7 @@ import asyncio
 import os
 import shutil
 import socket
-import subprocess
+import subprocess  # nosec B404 - controlled argv lists, no shell=True usage
 import time
 import yaml
 from datetime import datetime


### PR DESCRIPTION
Added a Bandit suppression comment for B404 on the import:
`import subprocess # nosec B404 - controlled argv lists, no shell=True usage`

Hardened download URL handling for B310 before urlopen(...):

- Added urlparse import.
- Added allowlists:
`ALLOWED_DOWNLOAD_SCHEMES = {"https"}`
`ALLOWED_DOWNLOAD_HOSTS = {"raw.githubusercontent.com"}`

Added _validate_download_url(url: str) to enforce scheme + host checks.

Updated download_script_if_missing(...):

It now calls `_validate_download_url(url)` before attempting urllib.request.urlopen(...).
