### PR TITLE
Add Dockerfile to run OpenVINO demos in a reproducible environment

### DIFF
--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -1,0 +1,28 @@
+FROM python:3.10-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    wget \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install OpenVINO
+RUN pip install --no-cache-dir openvino
+
+# Install common dependencies used in demos
+RUN pip install --no-cache-dir \
+    numpy \
+    onnx \
+    opencv-python \
+    torch \
+    transformers \
+    gradio
+
+# Set working directory
+WORKDIR /workspace
+
+# Clone the repository
+RUN git clone https://github.com/openvinotoolkit/openvino_build_deploy.git .
+
+CMD ["/bin/bash"]

--- a/scripts/check_openvino_env.py
+++ b/scripts/check_openvino_env.py
@@ -1,0 +1,31 @@
+import sys
+import importlib
+
+print("\n===== OpenVINO Environment Diagnostic =====\n")
+
+# Python version
+print("Python version:", sys.version)
+
+# Check OpenVINO installation
+try:
+    import openvino as ov
+    core = ov.Core()
+    print("\nOpenVINO version:", ov.__version__)
+    print("Available devices:")
+    for device in core.available_devices:
+        print(" -", device)
+except Exception as e:
+    print("\nOpenVINO check failed:", e)
+
+# Check required packages
+packages = ["numpy", "onnx", "gradio", "opencv-python", "torch", "transformers"]
+
+print("\nChecking required packages:\n")
+
+for pkg in packages:
+    if importlib.util.find_spec(pkg):
+        print(pkg, "✔ installed")
+    else:
+        print(pkg, "❌ missing")
+
+print("\n===========================================\n")

--- a/scripts/check_openvino_env.py
+++ b/scripts/check_openvino_env.py
@@ -1,26 +1,40 @@
 import sys
+import platform
 import importlib
 
 print("\n===== OpenVINO Environment Diagnostic =====\n")
 
-# Python version
+# System info
+print("System Information")
+print("------------------")
+print("OS:", platform.system(), platform.release())
+print("Machine:", platform.machine())
+print("Processor:", platform.processor())
+
+# Python info
+print("\nPython Information")
+print("------------------")
 print("Python version:", sys.version)
 
-# Check OpenVINO installation
+# OpenVINO
+print("\nOpenVINO Information")
+print("------------------")
+
 try:
     import openvino as ov
     core = ov.Core()
-    print("\nOpenVINO version:", ov.__version__)
+    print("OpenVINO version:", ov.__version__)
     print("Available devices:")
     for device in core.available_devices:
         print(" -", device)
 except Exception as e:
-    print("\nOpenVINO check failed:", e)
+    print("OpenVINO check failed:", e)
 
-# Check required packages
+# Required packages
 packages = ["numpy", "onnx", "gradio", "opencv-python", "torch", "transformers"]
 
-print("\nChecking required packages:\n")
+print("\nPackage Check")
+print("------------------")
 
 for pkg in packages:
     if importlib.util.find_spec(pkg):


### PR DESCRIPTION
### Summary

This PR adds a Dockerfile to help users run OpenVINO demos and reference kits in a consistent containerized environment.

### Motivation

Setting up the required dependencies for running demos in this repository may require installing OpenVINO, Python packages, and system libraries. Providing a Dockerfile simplifies this setup and ensures reproducible environments across different systems.

### Changes

* Added `docker/Dockerfile.demo`
* Installs OpenVINO runtime and common Python dependencies used in demos
* Provides a simple container environment to run examples from this repository

### Example Usage

```
docker build -t openvino-demo docker/
docker run --rm -it openvino-demo
```

### Benefits

* Simplifies environment setup
* Improves reproducibility
* Helps new users quickly run demos

If this approach looks good, I can also extend Docker support for additional demos or reference kits in the repository.
Closes #480 