### PR TITLE
Example updates and proxy fixes

### DIFF
--- a/ai_ref_kits/agentic_multimodal_travel_planer/download_and_run_models_Windows.bat
+++ b/ai_ref_kits/agentic_multimodal_travel_planer/download_and_run_models_Windows.bat
@@ -14,6 +14,10 @@ set LLM_PORT=8001
 set VLM_PORT=8002
 set PYTHON_SUPPORT=python_on
 set TARGET_DEVICE=
+set NO_PROXY=localhost,127.0.0.1
+set no_proxy=localhost,127.0.0.1
+set http_proxy=
+set https_proxy=
 
 REM Download and extract OVMS package
 if not exist "%OVMS_DIR%" (

--- a/ai_ref_kits/agentic_multimodal_travel_planer/start_ui.py
+++ b/ai_ref_kits/agentic_multimodal_travel_planer/start_ui.py
@@ -309,8 +309,8 @@ class TravelRouterClient:
 # Example prompts for the UI
 EXAMPLES = [
     "Which city is shown in this image?",
-    "Give me flights from Milan to Berlin for March 1st to March 10th",
-    "Give me hotels in Milan for March 1st to March 10th for 2 guests",
+    "Give me flights from Milan to Berlin for October 1st to October 10th",
+    "Give me hotels in Milan for October 1st to October 10th for 2 guests",
     (
         "Help me finding flights to the city "
         "in the image"


### PR DESCRIPTION
Changed default examples to October 2026 from March, since it caused an error when requesting past dates' trips.
Added proxy configuration for Windows script