### PR TITLE
fix: replace deprecated openvino.runtime imports with openvino namespace

### DIFF
--- a/ai_ref_kits/conversational_ai_chatbot/convert_and_optimize_chat.py
+++ b/ai_ref_kits/conversational_ai_chatbot/convert_and_optimize_chat.py
@@ -3,8 +3,8 @@ from pathlib import Path
 
 import numpy as np
 import openvino as ov
-from openvino.runtime import opset10 as ops
-from openvino.runtime import passes
+import openvino.opset10 as ops
+from openvino import passes
 from optimum.intel import OVModelForCausalLM, OVModelForFeatureExtraction, OVWeightQuantizationConfig, OVConfig, \
     OVQuantizer, OVModelForSequenceClassification
 from transformers import AutoTokenizer

--- a/demos/virtual_ai_assistant_demo/main.py
+++ b/demos/virtual_ai_assistant_demo/main.py
@@ -23,8 +23,8 @@ from llama_index.embeddings.huggingface_openvino import OpenVINOEmbedding
 from llama_index.llms.openvino_genai import OpenVINOGenAILLM
 from llama_index.postprocessor.openvino_rerank import OpenVINORerank
 from llama_index.vector_stores.chroma import ChromaVectorStore
-from openvino.runtime import opset10 as ops
-from openvino.runtime import passes
+import openvino.opset10 as ops
+from openvino import passes
 from optimum.exporters.openvino.convert import export_tokenizer
 from optimum.intel import OVModelForCausalLM, OVModelForFeatureExtraction, OVWeightQuantizationConfig, OVModelForSequenceClassification
 from transformers import AutoTokenizer


### PR DESCRIPTION
The openvino.runtime module was deprecated in OpenVINO 2025.2 and is scheduled for removal in 2026.0. Two files used bare imports with no try/except fallback which will cause ImportError on 2026.0. Updated both to use the modern top-level openvino namespace. Closes #499