### PR TITLE
Gradio + ONNX + OV bump +LangChain Text Splitters + Fixed vulnerabilities for Conversational AI Assistant kit

### DIFF
--- a/.github/reusable-steps/setup-hugging-face/action.yml
+++ b/.github/reusable-steps/setup-hugging-face/action.yml
@@ -19,7 +19,7 @@ runs:
       run: |
         if [ -n "$HF_TOKEN" ]; then  
           export PYTHONIOENCODING=utf-8
-          huggingface-cli login --token "$HF_TOKEN"
+          hf auth login --token "$HF_TOKEN"
         else
           echo "HF_TOKEN not set, continuing without login."
         fi

--- a/.github/reusable-steps/setup-hugging-face/action.yml
+++ b/.github/reusable-steps/setup-hugging-face/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Install Hugging Face CLI
       shell: bash
       run: |
-        uv pip install huggingface_hub hf_transfer hf_xet --system
+        uv pip install "huggingface_hub[cli]" hf_transfer hf_xet --system
     - name: Login to HF
       shell: bash
       env:
@@ -19,7 +19,12 @@ runs:
       run: |
         if [ -n "$HF_TOKEN" ]; then  
           export PYTHONIOENCODING=utf-8
-          hf auth login --token "$HF_TOKEN"
+          if command -v hf >/dev/null 2>&1; then
+            hf auth login --token "$HF_TOKEN"
+          else
+            # Back-compat for environments that only ship the legacy entrypoint.
+            huggingface-cli login --token "$HF_TOKEN"
+          fi
         else
           echo "HF_TOKEN not set, continuing without login."
         fi

--- a/ai_ref_kits/conversational_ai_chatbot/app.py
+++ b/ai_ref_kits/conversational_ai_chatbot/app.py
@@ -1,5 +1,6 @@
 import argparse
 import logging as log
+import platform
 import threading
 import time
 from pathlib import Path
@@ -32,6 +33,8 @@ TARGET_AUDIO_SAMPLE_RATE = 16000
 TARGET_AUDIO_SAMPLE_RATE_TTS = 44100
 
 MODEL_DIR = Path("model")
+# Optimum-Intel uses one InferRequest per compiled model; concurrent Gradio threads (e.g. chat
+# streaming while file upload reloads RAG) must not call the same OV model at once.
 inference_lock = threading.Lock()
 
 # Initialize Model variables
@@ -61,6 +64,29 @@ def _message_plain_text(content: Any) -> str:
     return ""
 
 
+def _openvino_runtime_device(device: str) -> str:
+    """Normalize device for OpenVINO on Linux/arm64 CI hosts.
+
+    ``AUTO`` compiles through a scheduler path that can fail for Distil-Whisper FP16 IR on
+    aarch64 (oneDNN matmul primitive); compiling directly for ``CPU`` avoids that failure.
+    """
+    if device.upper() == "AUTO" and platform.machine().lower() in ("aarch64", "arm64"):
+        return "CPU"
+    return device
+
+
+def _asr_openvino_config() -> Optional[dict]:
+    """Extra compile hints for Whisper on ARM64 where FP16 matmul kernels may be unavailable."""
+    if platform.machine().lower() not in ("aarch64", "arm64"):
+        return None
+    return {
+        "PERFORMANCE_HINT": "LATENCY",
+        "NUM_STREAMS": "1",
+        "INFERENCE_PRECISION_HINT": "f32",
+        "CACHE_DIR": "",
+    }
+
+
 def get_available_devices() -> Set[str]:
     """
     List all devices available for inference
@@ -86,8 +112,13 @@ def load_asr_model(model_dir: Path, device: str) -> None:
         log.error(f"Cannot find {model_dir}. Did you run convert_and_optimize_asr.py first?")
         return
 
+    device = _openvino_runtime_device(device)
+    load_kw: dict = {"device": device}
+    ov_cfg = _asr_openvino_config()
+    if ov_cfg is not None:
+        load_kw["ov_config"] = ov_cfg
     # create a distil-whisper model and its processor
-    asr_model = OVModelForSpeechSeq2Seq.from_pretrained(model_dir, device=device)
+    asr_model = OVModelForSpeechSeq2Seq.from_pretrained(model_dir, **load_kw)
     asr_processor = AutoProcessor.from_pretrained(model_dir)
 
     model_name = model_dir.name
@@ -108,6 +139,7 @@ def load_chat_model(model_dir: Path, device: str) -> Optional[OpenVINOLLM]:
         log.error(f"Cannot find {model_dir}. Did you run convert_and_optimize_chat.py first?")
         return None
 
+    device = _openvino_runtime_device(device)
     ov_config = {'PERFORMANCE_HINT': 'LATENCY', 'NUM_STREAMS': '1', "CACHE_DIR": ""}
     # load llama model and its tokenizer in the format of Llama Index
     return OpenVINOLLM(context_window=2048, model_id_or_path=str(model_dir), max_new_tokens=512, device_map=device,
@@ -128,6 +160,7 @@ def load_embedding_model(model_dir: Path, device: str) -> Optional[OpenVINOEmbed
         log.error(f"Cannot find {model_dir}. Did you run convert_and_optimize_chat.py first?")
         return None
 
+    device = _openvino_runtime_device(device)
     # load embedding model in the format of Llama Index
     return OpenVINOEmbedding(str(model_dir), device=device, embed_batch_size=1, model_kwargs={"dynamic_shapes": False})
 
@@ -146,6 +179,7 @@ def load_reranker_model(model_dir: Path, device: str) -> Optional[OpenVINORerank
         log.error(f"Cannot find {model_dir}. Did you run convert_and_optimize_chat.py first?")
         return None
 
+    device = _openvino_runtime_device(device)
     # load reranker model in the format of Llama Index
     return OpenVINORerank(model_id_or_path=str(model_dir), device=device, top_n=3)
 
@@ -258,23 +292,22 @@ def load_context(file_path: Path | str | None) -> None:
     # create a splitter to split the document into chunks
     splitter = LangchainNodeParser(RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=100))
 
-    # set the embedding model
-    
-    # Create index using LlamaIndex's default vector store (in-memory) and the splitter
-    index = VectorStoreIndex.from_documents(
-        [document], 
-        transformations=[splitter], 
-        embed_model=ov_embedding
-    )
+    with inference_lock:
+        # Create index using LlamaIndex's default vector store (in-memory) and the splitter
+        index = VectorStoreIndex.from_documents(
+            [document],
+            transformations=[splitter],
+            embed_model=ov_embedding,
+        )
 
-    # Build RAG chat engine with reranker and memory
-    ov_chat_engine = index.as_chat_engine(
-        llm=ov_llm,
-        chat_mode=ChatMode.CONTEXT,
-        system_prompt=chatbot_config["system_configuration"],
-        memory=memory,
-        node_postprocessors=[ov_reranker]
-    )
+        # Build RAG chat engine with reranker and memory
+        ov_chat_engine = index.as_chat_engine(
+            llm=ov_llm,
+            chat_mode=ChatMode.CONTEXT,
+            system_prompt=chatbot_config["system_configuration"],
+            memory=memory,
+            node_postprocessors=[ov_reranker],
+        )
 
 def generate_initial_greeting() -> str:
     """
@@ -283,7 +316,8 @@ def generate_initial_greeting() -> str:
     Returns:
         Generated greeting
     """
-    return ov_chat_engine.chat(chatbot_config["greet_the_user_prompt"]).response
+    with inference_lock:
+        return ov_chat_engine.chat(chatbot_config["greet_the_user_prompt"]).response
 
 
 def chat(history: List[dict]) -> List[dict]:
@@ -348,8 +382,12 @@ def transcribe(audio: Tuple[int, np.ndarray], prompt: str, conversation: List[di
         # use streamer to show transcription word by word
         text_streamer = TextIteratorStreamer(asr_processor, skip_prompt=True, skip_special_tokens=True)
 
+        def _run_asr() -> None:
+            with inference_lock:
+                asr_model.generate(input_features=input_features, streamer=text_streamer)
+
         # transcribe in the background to deliver response token by token
-        thread = Thread(target=asr_model.generate, kwargs={"input_features": input_features, "streamer": text_streamer})
+        thread = Thread(target=_run_asr)
         thread.start()
 
         conversation = list(conversation)
@@ -388,8 +426,10 @@ def synthesize(conversation: List[dict], audio: Tuple[int, np.ndarray]) -> Optio
     prompt = _message_plain_text(conversation[-1].get("content")) if conversation else ""
 
     start_time = time.time()
-    # English
-    speech = ov_tts_model.tts_to_file(prompt, ov_tts_model.hps.data.spk2id['EN-US'], output_path=None, speed=1.0)
+    with inference_lock:
+        speech = ov_tts_model.tts_to_file(
+            prompt, ov_tts_model.hps.data.spk2id["EN-US"], output_path=None, speed=1.0
+        )
     end_time = time.time()
 
     log.info(f"TTS model response time: {end_time - start_time:.2f} seconds")

--- a/ai_ref_kits/conversational_ai_chatbot/app.py
+++ b/ai_ref_kits/conversational_ai_chatbot/app.py
@@ -203,35 +203,36 @@ def load_tts_model() -> None:
     log.info(f"Running {type(ov_tts_model).__name__} on {ov_tts_model.device.__str__().upper()}")
 
 
-def load_file(file_path: Path) -> Document:
+def load_file(file_path: Path | str) -> Document:
     """
     Load text or pdf document using PyMuPDF for PDFs and standard reading for text files.
     
     Params:
-        file_path: the path to the document
+        file_path: the path to the document (``pathlib.Path`` or Gradio file value such as ``NamedString``)
     Returns:
         A document in LLama Index format
     """
-    ext = file_path.suffix
+    path = Path(str(file_path))
+    ext = path.suffix
     if ext == ".pdf":
         # Using PyMuPDF (fitz) to read PDF content
         text = ""
-        with fitz.open(file_path) as pdf:
+        with fitz.open(path) as pdf:
             for page in pdf:
                 text += page.get_text("text") + "\n"  # Extract text from each page
-            return Document(text=text, metadata={"file_name": file_path.name})
+            return Document(text=text, metadata={"file_name": path.name})
     
     elif ext == ".txt":
         # Reading text files as usual
-        with open(file_path) as f:
+        with open(path) as f:
             content = f.read()
-            return Document(text=content, metadata={"file_name": file_path.name})
+            return Document(text=content, metadata={"file_name": path.name})
     
     else:
         raise ValueError(f"{ext} file is not supported for now")
 
 
-def load_context(file_path: Path) -> None:
+def load_context(file_path: Path | str | None) -> None:
     """
     Load context (document) and create a RAG pipeline
     Params:

--- a/ai_ref_kits/conversational_ai_chatbot/app.py
+++ b/ai_ref_kits/conversational_ai_chatbot/app.py
@@ -150,9 +150,15 @@ def load_chat_model(model_dir: Path, device: str) -> Tuple[OVModelForCausalLM, A
     ov_config = {"PERFORMANCE_HINT": "LATENCY", "NUM_STREAMS": "1", "CACHE_DIR": ""}
     tokenizer = AutoTokenizer.from_pretrained(model_dir)
     model = OVModelForCausalLM.from_pretrained(model_dir, device=device, ov_config=ov_config)
-    log.info(
-        f"Running {model_dir} on {','.join(model.request.get_compiled_model().get_property('EXECUTION_DEVICES'))}"
-    )
+    exec_devs = None
+    try:
+        req = getattr(model, "request", None)
+        compiled = req.get_compiled_model() if hasattr(req, "get_compiled_model") else req
+        if compiled is not None and hasattr(compiled, "get_property"):
+            exec_devs = compiled.get_property("EXECUTION_DEVICES")
+    except Exception:
+        exec_devs = None
+    log.info(f"Running {model_dir} on {','.join(exec_devs) if exec_devs else device}")
     return model, tokenizer
 
 
@@ -173,9 +179,15 @@ def load_embedding_model(model_dir: Path, device: str) -> Tuple[OVModelForFeatur
     device = _openvino_runtime_device(device)
     tokenizer = AutoTokenizer.from_pretrained(model_dir)
     model = OVModelForFeatureExtraction.from_pretrained(model_dir, device=device)
-    log.info(
-        f"Running {model_dir} on {','.join(model.request.get_compiled_model().get_property('EXECUTION_DEVICES'))}"
-    )
+    exec_devs = None
+    try:
+        req = getattr(model, "request", None)
+        compiled = req.get_compiled_model() if hasattr(req, "get_compiled_model") else req
+        if compiled is not None and hasattr(compiled, "get_property"):
+            exec_devs = compiled.get_property("EXECUTION_DEVICES")
+    except Exception:
+        exec_devs = None
+    log.info(f"Running {model_dir} on {','.join(exec_devs) if exec_devs else device}")
     return model, tokenizer
 
 
@@ -196,9 +208,15 @@ def load_reranker_model(model_dir: Path, device: str) -> Tuple[OVModelForSequenc
     device = _openvino_runtime_device(device)
     tokenizer = AutoTokenizer.from_pretrained(model_dir)
     model = OVModelForSequenceClassification.from_pretrained(model_dir, device=device)
-    log.info(
-        f"Running {model_dir} on {','.join(model.request.get_compiled_model().get_property('EXECUTION_DEVICES'))}"
-    )
+    exec_devs = None
+    try:
+        req = getattr(model, "request", None)
+        compiled = req.get_compiled_model() if hasattr(req, "get_compiled_model") else req
+        if compiled is not None and hasattr(compiled, "get_property"):
+            exec_devs = compiled.get_property("EXECUTION_DEVICES")
+    except Exception:
+        exec_devs = None
+    log.info(f"Running {model_dir} on {','.join(exec_devs) if exec_devs else device}")
     return model, tokenizer
 
 
@@ -240,9 +258,6 @@ def load_tts_model() -> None:
 
     # CPU is sufficient for real-time inference.
     ov_tts_model = TTS(language='EN', device='cpu')
-    
-    # Compile the model with OpenVINO backend for accelerated inference
-    ov_tts_model.model.infer = torch.compile(ov_tts_model.model.infer, backend='openvino')
 
     log.info(f"Running {type(ov_tts_model).__name__} on {ov_tts_model.device.__str__().upper()}")
 
@@ -405,8 +420,10 @@ def chat(history: List[dict]) -> List[dict]:
 
     streamer = TextIteratorStreamer(chat_tokenizer, skip_prompt=True, skip_special_tokens=True)
 
+    model_inputs = chat_tokenizer(prompt, return_tensors="pt")
     gen_kwargs = dict(
-        inputs=chat_tokenizer(prompt, return_tensors="np")["input_ids"],
+        input_ids=model_inputs["input_ids"],
+        attention_mask=model_inputs.get("attention_mask"),
         streamer=streamer,
         max_new_tokens=512,
         do_sample=True,

--- a/ai_ref_kits/conversational_ai_chatbot/app.py
+++ b/ai_ref_kits/conversational_ai_chatbot/app.py
@@ -450,7 +450,10 @@ def create_UI(initial_message: str, example_pdf_path: Path) -> gr.Blocks:
     with gr.Blocks(title="Adrishuo - the Conversational AI Chatbot") as demo:
         gr.Markdown(chatbot_config["instructions"])
         with gr.Row():
-            file_uploader_ui = gr.File(label="Hotel guide", file_types=[".pdf", ".txt"], value=str(example_pdf_path), scale=1)
+            file_uploader_ui = gr.File(
+                label="Hotel guide", file_types=[".pdf", ".txt"], value=str(example_pdf_path), scale=1
+            )
+
             with gr.Column(scale=4):
                 chatbot_ui = gr.Chatbot(
                     value=[{"role": "assistant", "content": initial_message}],

--- a/ai_ref_kits/conversational_ai_chatbot/app.py
+++ b/ai_ref_kits/conversational_ai_chatbot/app.py
@@ -4,9 +4,9 @@ import threading
 import time
 from pathlib import Path
 from threading import Thread
-from typing import Tuple, List, Optional, Set
+from typing import Any, Tuple, List, Optional, Set
 
-import fitz  # PyMuPDF
+import pymupdf as fitz  # PyPI: pymupdf
 import gradio as gr
 import librosa
 import numpy as np
@@ -44,6 +44,21 @@ ov_chat_engine: Optional[BaseChatEngine] = None
 ov_tts_model: Optional[torch.Tensor] = None
 
 chatbot_config = {}
+
+
+def _message_plain_text(content: Any) -> str:
+    """Plain text from Gradio Chatbot message content (string or normalized multimodal list)."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: List[str] = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                parts.append(str(item.get("text", "")))
+            elif isinstance(item, str):
+                parts.append(item)
+        return "".join(parts)
+    return ""
 
 
 def get_available_devices() -> Set[str]:
@@ -270,41 +285,44 @@ def generate_initial_greeting() -> str:
     return ov_chat_engine.chat(chatbot_config["greet_the_user_prompt"]).response
 
 
-def chat(history: List[List[str]]) -> List[List[str]]:
+def chat(history: List[dict]) -> List[dict]:
     """
     Chat function. It generates response based on a prompt
 
     Params:
-        history: history of the messages (conversation) so far
+        history: OpenAI-style chat messages (role / content) from the Chatbot
     Returns:
         History with the latest chat's response (yields partial response)
     """
-    # no document is loaded
+    history = list(history)
     if isinstance(ov_chat_engine, SimpleChatEngine):
-        history[-1][1] = "No guide is provided, so I cannot answer this question. Please upload the hotel guide."
+        history.append({
+            "role": "assistant",
+            "content": "No guide is provided, so I cannot answer this question. Please upload the hotel guide.",
+        })
         yield history
         return
 
-    # get token by token and merge to the final response
-    history[-1][1] = ""
+    user_msg = _message_plain_text(history[-1].get("content")) if history and history[-1].get("role") == "user" else ""
+
+    history.append({"role": "assistant", "content": ""})
     with inference_lock:
         start_time = time.time()
 
-        chat_streamer = ov_chat_engine.stream_chat(history[-1][0]).response_gen
+        chat_streamer = ov_chat_engine.stream_chat(user_msg).response_gen
         for partial_text in chat_streamer:
-            history[-1][1] += partial_text
-            # "return" partial response
+            history[-1]["content"] += partial_text
             yield history
 
         end_time = time.time()
 
-        # 75 words ~= 100 tokens
-        tokens = len(history[-1][1].split(" ")) * 4 / 3
+        reply = _message_plain_text(history[-1].get("content"))
+        tokens = len(reply.split(" ")) * 4 / 3
         processing_time = end_time - start_time
         log.info(f"Chat model response time: {processing_time:.2f} seconds ({tokens / processing_time:.2f} tokens/s)")
 
 
-def transcribe(audio: Tuple[int, np.ndarray], prompt: str, conversation: List[List[str]]) -> List[List[str]]:
+def transcribe(audio: Tuple[int, np.ndarray], prompt: str, conversation: List[dict]) -> List[dict]:
     """
     Transcribe audio to text
 
@@ -333,11 +351,10 @@ def transcribe(audio: Tuple[int, np.ndarray], prompt: str, conversation: List[Li
         thread = Thread(target=asr_model.generate, kwargs={"input_features": input_features, "streamer": text_streamer})
         thread.start()
 
-        conversation.append(["", None])
-        # get token by token and merge to the final response
+        conversation = list(conversation)
+        conversation.append({"role": "user", "content": ""})
         for partial_text in text_streamer:
-            conversation[-1][0] += partial_text
-            # "return" partial response
+            conversation[-1]["content"] += partial_text
             yield conversation
 
         end_time = time.time()  # End time for ASR process
@@ -346,13 +363,14 @@ def transcribe(audio: Tuple[int, np.ndarray], prompt: str, conversation: List[Li
         # wait for the thread
         thread.join()
     else:
-        conversation.append([prompt, None])
+        conversation = list(conversation)
+        conversation.append({"role": "user", "content": prompt})
         yield conversation
 
     return conversation
 
 
-def synthesize(conversation: List[List[str]], audio: Tuple[int, np.ndarray]) -> Optional[Tuple[int, np.ndarray]]:
+def synthesize(conversation: List[dict], audio: Tuple[int, np.ndarray]) -> Optional[Tuple[int, np.ndarray]]:
     """
     Synthesizes speech from chatbot's response
 
@@ -366,7 +384,7 @@ def synthesize(conversation: List[List[str]], audio: Tuple[int, np.ndarray]) -> 
     if not audio:
         return None
 
-    prompt = conversation[-1][1]
+    prompt = _message_plain_text(conversation[-1].get("content")) if conversation else ""
 
     start_time = time.time()
     # English
@@ -388,12 +406,15 @@ def create_UI(initial_message: str, example_pdf_path: Path) -> gr.Blocks:
     Returns:
         Demo UI
     """
-    with gr.Blocks(theme="base", title="Adrishuo - the Conversational AI Chatbot") as demo:
+    with gr.Blocks(title="Adrishuo - the Conversational AI Chatbot") as demo:
         gr.Markdown(chatbot_config["instructions"])
         with gr.Row():
             file_uploader_ui = gr.File(label="Hotel guide", file_types=[".pdf", ".txt"], value=str(example_pdf_path), scale=1)
             with gr.Column(scale=4):
-                chatbot_ui = gr.Chatbot(value=[[None, initial_message]], label="Chatbot")
+                chatbot_ui = gr.Chatbot(
+                    value=[{"role": "assistant", "content": initial_message}],
+                    label="Chatbot",
+                )
                 with gr.Tab(label="Voice"):
                     with gr.Row():
                         input_audio_ui = gr.Audio(sources=["microphone"], label="Your voice input")
@@ -409,10 +430,12 @@ def create_UI(initial_message: str, example_pdf_path: Path) -> gr.Blocks:
         gr.on(triggers=[input_audio_ui.change, input_text_ui.change], inputs=[input_audio_ui, input_text_ui], outputs=submit_btn,
               fn=lambda x, y: gr.Button(interactive=True) if bool(x) ^ bool(y) else gr.Button(interactive=False))
 
-        file_uploader_ui.change(lambda: [[None, initial_message]], outputs=chatbot_ui) \
+        reset_chat = lambda: [{"role": "assistant", "content": initial_message}]
+
+        file_uploader_ui.change(reset_chat, outputs=chatbot_ui) \
             .then(load_context, inputs=file_uploader_ui)
 
-        clear_btn.click(lambda: [[None, initial_message]], outputs=chatbot_ui) \
+        clear_btn.click(reset_chat, outputs=chatbot_ui) \
             .then(lambda: gr.Button(interactive=False), outputs=clear_btn)
 
         # block buttons, clear output audio, do the transcription and conversation, clear input audio, unblock buttons
@@ -472,7 +495,7 @@ def run(asr_model_dir: Path, asr_model_device: str, chat_model_dir: Path, chat_m
 
     print("Demo is ready!", flush=True) # Required for the CI to detect readiness
     # launch demo
-    demo.queue().launch(share=public_interface)
+    demo.queue().launch(share=public_interface, theme="base")
 
 
 if __name__ == "__main__":
@@ -480,7 +503,7 @@ if __name__ == "__main__":
     parser.add_argument("--asr_model", type=str, default="model/distil-whisper-large-v3-FP16", help="Path of the automatic speech recognition model directory")
     parser.add_argument("--asr_model_device", type=str, default="CPU", choices=["AUTO", "GPU", "CPU", "NPU"], help="Device to run ASR model inference on")
     parser.add_argument("--chat_model", type=str, default="model/llama3.2-3B-INT4", help="Path to the chat model directory")
-    parser.add_argument("--chat_model_device", type=str, default="GPU", choices=["AUTO", "GPU", "CPU", "NPU"], help="Device to run chat model inference on")
+    parser.add_argument("--chat_model_device", type=str, default="CPU", choices=["AUTO", "GPU", "CPU", "NPU"], help="Device to run chat model inference on")
     parser.add_argument("--embedding_model", type=str, default="model/bge-small-FP32", help="Path to the embedding model directory")
     parser.add_argument("--embedding_model_device", type=str, default="CPU", choices=["AUTO", "GPU", "CPU", "NPU"], help="Device to run embedding model inference on")
     parser.add_argument("--reranker_model", type=str, default="model/bge-reranker-large-FP32", help="Path to the reranker model directory")

--- a/ai_ref_kits/conversational_ai_chatbot/app.py
+++ b/ai_ref_kits/conversational_ai_chatbot/app.py
@@ -5,7 +5,8 @@ import threading
 import time
 from pathlib import Path
 from threading import Thread
-from typing import Any, Tuple, List, Optional, Set
+from dataclasses import dataclass
+from typing import Any, Tuple, List, Optional, Set, Dict
 
 import pymupdf as fitz  # PyPI: pymupdf
 import gradio as gr
@@ -16,16 +17,13 @@ import torch
 import yaml
 import nltk
 from langchain_text_splitters import RecursiveCharacterTextSplitter
-from llama_index.core import Document, VectorStoreIndex, Settings
-from llama_index.core.chat_engine import SimpleChatEngine
-from llama_index.core.chat_engine.types import BaseChatEngine, ChatMode
-from llama_index.core.memory import ChatMemoryBuffer
-from llama_index.core.node_parser import LangchainNodeParser
-from llama_index.embeddings.huggingface_openvino import OpenVINOEmbedding
-from llama_index.llms.openvino import OpenVINOLLM
-from llama_index.postprocessor.openvino_rerank import OpenVINORerank
-from optimum.intel import OVModelForSpeechSeq2Seq
-from transformers import AutoProcessor, TextIteratorStreamer
+from optimum.intel import (
+    OVModelForCausalLM,
+    OVModelForFeatureExtraction,
+    OVModelForSequenceClassification,
+    OVModelForSpeechSeq2Seq,
+)
+from transformers import AutoProcessor, AutoTokenizer, TextIteratorStreamer
 from melo.api import TTS
 
 # Global variables initialization
@@ -40,10 +38,19 @@ inference_lock = threading.Lock()
 # Initialize Model variables
 asr_model: Optional[OVModelForSpeechSeq2Seq] = None
 asr_processor: Optional[AutoProcessor] = None
-ov_llm: Optional[OpenVINOLLM] = None
-ov_embedding: Optional[OpenVINOEmbedding] = None
-ov_reranker: Optional[OpenVINORerank] = None
-ov_chat_engine: Optional[BaseChatEngine] = None
+chat_model: Optional[OVModelForCausalLM] = None
+chat_tokenizer: Optional[Any] = None
+embedding_model: Optional[OVModelForFeatureExtraction] = None
+embedding_tokenizer: Optional[Any] = None
+reranker_model: Optional[OVModelForSequenceClassification] = None
+reranker_tokenizer: Optional[Any] = None
+
+@dataclass(frozen=True)
+class _Chunk:
+    text: str
+    embedding: np.ndarray  # (dim,)
+
+rag_chunks: List[_Chunk] = []
 ov_tts_model: Optional[torch.Tensor] = None
 
 chatbot_config = {}
@@ -125,7 +132,7 @@ def load_asr_model(model_dir: Path, device: str) -> None:
     log.info(f"Running {model_name} on {','.join(asr_model.encoder.request.get_property('EXECUTION_DEVICES'))}")
 
 
-def load_chat_model(model_dir: Path, device: str) -> Optional[OpenVINOLLM]:
+def load_chat_model(model_dir: Path, device: str) -> Tuple[OVModelForCausalLM, Any]:
     """
     Load chat model
 
@@ -133,20 +140,23 @@ def load_chat_model(model_dir: Path, device: str) -> Optional[OpenVINOLLM]:
         model_dir: dir with the chat model
         device: device to run the model inference on
     Returns:
-        OpenVINO LLM model in LLama Index
+        (OpenVINO causal LM, tokenizer)
     """
     if not model_dir.exists():
         log.error(f"Cannot find {model_dir}. Did you run convert_and_optimize_chat.py first?")
-        return None
+        raise FileNotFoundError(model_dir)
 
     device = _openvino_runtime_device(device)
-    ov_config = {'PERFORMANCE_HINT': 'LATENCY', 'NUM_STREAMS': '1', "CACHE_DIR": ""}
-    # load llama model and its tokenizer in the format of Llama Index
-    return OpenVINOLLM(context_window=2048, model_id_or_path=str(model_dir), max_new_tokens=512, device_map=device,
-                       model_kwargs={"ov_config": ov_config}, generate_kwargs={"do_sample": True, "temperature": 0.7, "top_k": 50, "top_p": 0.95})
+    ov_config = {"PERFORMANCE_HINT": "LATENCY", "NUM_STREAMS": "1", "CACHE_DIR": ""}
+    tokenizer = AutoTokenizer.from_pretrained(model_dir)
+    model = OVModelForCausalLM.from_pretrained(model_dir, device=device, ov_config=ov_config)
+    log.info(
+        f"Running {model_dir} on {','.join(model.request.get_compiled_model().get_property('EXECUTION_DEVICES'))}"
+    )
+    return model, tokenizer
 
 
-def load_embedding_model(model_dir: Path, device: str) -> Optional[OpenVINOEmbedding]:
+def load_embedding_model(model_dir: Path, device: str) -> Tuple[OVModelForFeatureExtraction, Any]:
     """
     Load embedding model
 
@@ -154,34 +164,42 @@ def load_embedding_model(model_dir: Path, device: str) -> Optional[OpenVINOEmbed
         model_dir: dir with the embedding model
         device: device to run the model inference on
     Returns:
-        OpenVINO Embedding model in LLama Index
+        (OpenVINO feature extractor, tokenizer)
     """
     if not model_dir.exists():
         log.error(f"Cannot find {model_dir}. Did you run convert_and_optimize_chat.py first?")
-        return None
+        raise FileNotFoundError(model_dir)
 
     device = _openvino_runtime_device(device)
-    # load embedding model in the format of Llama Index
-    return OpenVINOEmbedding(str(model_dir), device=device, embed_batch_size=1, model_kwargs={"dynamic_shapes": False})
+    tokenizer = AutoTokenizer.from_pretrained(model_dir)
+    model = OVModelForFeatureExtraction.from_pretrained(model_dir, device=device)
+    log.info(
+        f"Running {model_dir} on {','.join(model.request.get_compiled_model().get_property('EXECUTION_DEVICES'))}"
+    )
+    return model, tokenizer
 
 
-def load_reranker_model(model_dir: Path, device: str) -> Optional[OpenVINORerank]:
+def load_reranker_model(model_dir: Path, device: str) -> Tuple[OVModelForSequenceClassification, Any]:
     """
-    Load embedding model
+    Load reranker model
 
     Params:
         model_dir: dir with the reranker model
         device: device to run the model inference on
     Returns:
-        OpenVINO Reranker model in LLama Index
+        (OpenVINO sequence classifier, tokenizer)
     """
     if not model_dir.exists():
         log.error(f"Cannot find {model_dir}. Did you run convert_and_optimize_chat.py first?")
-        return None
+        raise FileNotFoundError(model_dir)
 
     device = _openvino_runtime_device(device)
-    # load reranker model in the format of Llama Index
-    return OpenVINORerank(model_id_or_path=str(model_dir), device=device, top_n=3)
+    tokenizer = AutoTokenizer.from_pretrained(model_dir)
+    model = OVModelForSequenceClassification.from_pretrained(model_dir, device=device)
+    log.info(
+        f"Running {model_dir} on {','.join(model.request.get_compiled_model().get_property('EXECUTION_DEVICES'))}"
+    )
+    return model, tokenizer
 
 
 def load_rag_models(chat_model_dir: Path, chat_model_device: str, embedding_model_dir: Path, embedding_model_device: str, reranker_model_dir: Path, reranker_model_device: str, personality_file_path: Path) -> None:
@@ -197,26 +215,18 @@ def load_rag_models(chat_model_dir: Path, chat_model_device: str, embedding_mode
         reranker_model_device: device to run reranker model inference on
         personality_file_path: path to the chatbot personality specification file
     """
-    global ov_llm, ov_embedding, ov_reranker, ov_chat_engine, chatbot_config
+    global chat_model, chat_tokenizer, embedding_model, embedding_tokenizer, reranker_model, reranker_tokenizer, chatbot_config
 
     with open(personality_file_path) as f:
         chatbot_config = yaml.safe_load(f)
 
-    # embedding model
-    ov_embedding = load_embedding_model(embedding_model_dir, embedding_model_device)
-    log.info(f"Running {embedding_model_dir} on {','.join(ov_embedding._model.request.get_property('EXECUTION_DEVICES'))}")
-
-    # reranker model
-    ov_reranker = load_reranker_model(reranker_model_dir, reranker_model_device)
-    log.info(f"Running {reranker_model_dir} on {','.join(ov_reranker._model.request.get_property('EXECUTION_DEVICES'))}")
-
-    # chat model
-    ov_llm = load_chat_model(chat_model_dir, chat_model_device)
-    log.info(f"Running {chat_model_dir} on {','.join(ov_llm._model.request.get_compiled_model().get_property('EXECUTION_DEVICES'))}")
-
-    # chat engine
-    ov_chat_engine = SimpleChatEngine.from_defaults(llm=ov_llm, system_prompt=chatbot_config["system_configuration"],
-                                                    memory=ChatMemoryBuffer.from_defaults())
+    embedding_model, embedding_tokenizer = load_embedding_model(
+        embedding_model_dir, embedding_model_device
+    )
+    reranker_model, reranker_tokenizer = load_reranker_model(
+        reranker_model_dir, reranker_model_device
+    )
+    chat_model, chat_tokenizer = load_chat_model(chat_model_dir, chat_model_device)
 
 
 def load_tts_model() -> None:
@@ -237,14 +247,14 @@ def load_tts_model() -> None:
     log.info(f"Running {type(ov_tts_model).__name__} on {ov_tts_model.device.__str__().upper()}")
 
 
-def load_file(file_path: Path | str) -> Document:
+def load_file(file_path: Path | str) -> str:
     """
     Load text or pdf document using PyMuPDF for PDFs and standard reading for text files.
     
     Params:
         file_path: the path to the document (``pathlib.Path`` or Gradio file value such as ``NamedString``)
     Returns:
-        A document in LLama Index format
+        Full extracted text
     """
     path = Path(str(file_path))
     ext = path.suffix
@@ -254,16 +264,65 @@ def load_file(file_path: Path | str) -> Document:
         with fitz.open(path) as pdf:
             for page in pdf:
                 text += page.get_text("text") + "\n"  # Extract text from each page
-            return Document(text=text, metadata={"file_name": path.name})
+            return text
     
     elif ext == ".txt":
         # Reading text files as usual
         with open(path) as f:
-            content = f.read()
-            return Document(text=content, metadata={"file_name": path.name})
+            return f.read()
     
     else:
         raise ValueError(f"{ext} file is not supported for now")
+
+
+def _mean_pool(last_hidden_state: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:
+    mask = attention_mask.astype(np.float32)
+    mask = np.expand_dims(mask, axis=-1)  # (bs, seq, 1)
+    summed = (last_hidden_state * mask).sum(axis=1)
+    denom = np.clip(mask.sum(axis=1), a_min=1e-9, a_max=None)
+    return summed / denom
+
+
+def _embed_texts(texts: List[str]) -> np.ndarray:
+    """Return embeddings shape (n, dim)."""
+    assert embedding_model is not None and embedding_tokenizer is not None
+    encoded = embedding_tokenizer(
+        texts, padding=True, truncation=True, max_length=512, return_tensors="np"
+    )
+    # Optimum-Intel OpenVINO models accept numpy arrays and return numpy arrays
+    outputs = embedding_model(**encoded)
+    # Feature-extraction models return last_hidden_state-like array as first output
+    last_hidden = outputs[0]
+    pooled = _mean_pool(last_hidden, encoded["attention_mask"])
+    # L2 normalize
+    norms = np.linalg.norm(pooled, axis=1, keepdims=True)
+    return pooled / np.clip(norms, 1e-12, None)
+
+
+def _cosine_top_k(query_emb: np.ndarray, mat: np.ndarray, k: int) -> List[int]:
+    # query_emb: (dim,), mat: (n, dim) already normalized => dot = cosine
+    scores = mat @ query_emb
+    if k >= scores.shape[0]:
+        return list(np.argsort(-scores))
+    idx = np.argpartition(-scores, kth=k - 1)[:k]
+    idx = idx[np.argsort(-scores[idx])]
+    return idx.tolist()
+
+
+def _rerank(query: str, candidates: List[str], top_n: int = 3) -> List[str]:
+    if reranker_model is None or reranker_tokenizer is None:
+        return candidates[:top_n]
+    pairs = [(query, c) for c in candidates]
+    encoded = reranker_tokenizer(
+        pairs, padding=True, truncation=True, max_length=512, return_tensors="np"
+    )
+    outputs = reranker_model(**encoded)
+    logits = outputs[0]
+    # assume higher logit => more relevant; handle (bs,1) or (bs,2)
+    scores = logits.reshape(logits.shape[0], -1)
+    scores = scores[:, -1]
+    order = np.argsort(-scores)
+    return [candidates[i] for i in order[:top_n]]
 
 
 def load_context(file_path: Path | str | None) -> None:
@@ -272,42 +331,20 @@ def load_context(file_path: Path | str | None) -> None:
     Params:
         file_path: the path to the document
     """
-    global ov_chat_engine
+    global rag_chunks
+    rag_chunks = []
 
-    # Create memory buffer for chat history
-    memory = ChatMemoryBuffer.from_defaults()
-
-    # if no file is provided, use the default chat engine (not RAG based)
     if not file_path:
-        ov_chat_engine = SimpleChatEngine.from_defaults(
-            llm=ov_llm,
-            system_prompt=chatbot_config["system_configuration"],
-            memory=memory
-        )
         return
 
-    # load the document
-    document = load_file(file_path)
-
-    # create a splitter to split the document into chunks
-    splitter = LangchainNodeParser(RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=100))
+    raw_text = load_file(file_path)
+    splitter = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=100)
+    chunks = [c.strip() for c in splitter.split_text(raw_text) if c.strip()]
 
     with inference_lock:
-        # Create index using LlamaIndex's default vector store (in-memory) and the splitter
-        index = VectorStoreIndex.from_documents(
-            [document],
-            transformations=[splitter],
-            embed_model=ov_embedding,
-        )
+        embs = _embed_texts(chunks)
 
-        # Build RAG chat engine with reranker and memory
-        ov_chat_engine = index.as_chat_engine(
-            llm=ov_llm,
-            chat_mode=ChatMode.CONTEXT,
-            system_prompt=chatbot_config["system_configuration"],
-            memory=memory,
-            node_postprocessors=[ov_reranker],
-        )
+    rag_chunks = [_Chunk(text=t, embedding=embs[i]) for i, t in enumerate(chunks)]
 
 def generate_initial_greeting() -> str:
     """
@@ -316,8 +353,8 @@ def generate_initial_greeting() -> str:
     Returns:
         Generated greeting
     """
-    with inference_lock:
-        return ov_chat_engine.chat(chatbot_config["greet_the_user_prompt"]).response
+    # simple, non-RAG greeting
+    return chatbot_config.get("greeting", "Hello! How can I help you today?")
 
 
 def chat(history: List[dict]) -> List[dict]:
@@ -330,31 +367,72 @@ def chat(history: List[dict]) -> List[dict]:
         History with the latest chat's response (yields partial response)
     """
     history = list(history)
-    if isinstance(ov_chat_engine, SimpleChatEngine):
-        history.append({
-            "role": "assistant",
-            "content": "No guide is provided, so I cannot answer this question. Please upload the hotel guide.",
-        })
-        yield history
-        return
+    user_msg = (
+        _message_plain_text(history[-1].get("content"))
+        if history and history[-1].get("role") == "user"
+        else ""
+    )
 
-    user_msg = _message_plain_text(history[-1].get("content")) if history and history[-1].get("role") == "user" else ""
+    # retrieve context
+    context_blocks: List[str] = []
+    if rag_chunks and user_msg:
+        with inference_lock:
+            q = _embed_texts([user_msg])[0]
+        mat = np.stack([c.embedding for c in rag_chunks], axis=0)
+        top_idx = _cosine_top_k(q, mat, k=6)
+        candidates = [rag_chunks[i].text for i in top_idx]
+        context_blocks = _rerank(user_msg, candidates, top_n=3)
+
+    sys_prompt = chatbot_config.get("system_configuration", "")
+    context_text = "\n\n".join(
+        f"[CONTEXT {i+1}]\n{t}" for i, t in enumerate(context_blocks)
+    )
+    if context_text:
+        sys_prompt = f"{sys_prompt}\n\nUse the following context to answer:\n{context_text}".strip()
+
+    messages: List[Dict[str, str]] = []
+    if sys_prompt:
+        messages.append({"role": "system", "content": sys_prompt})
+    for m in history:
+        role = m.get("role")
+        if role in ("user", "assistant"):
+            messages.append({"role": role, "content": _message_plain_text(m.get('content'))})
+
+    assert chat_model is not None and chat_tokenizer is not None
+    prompt = chat_tokenizer.apply_chat_template(
+        messages, tokenize=False, add_generation_prompt=True
+    )
+
+    streamer = TextIteratorStreamer(chat_tokenizer, skip_prompt=True, skip_special_tokens=True)
+
+    gen_kwargs = dict(
+        inputs=chat_tokenizer(prompt, return_tensors="np")["input_ids"],
+        streamer=streamer,
+        max_new_tokens=512,
+        do_sample=True,
+        temperature=0.7,
+        top_p=0.95,
+        top_k=50,
+    )
 
     history.append({"role": "assistant", "content": ""})
-    with inference_lock:
-        start_time = time.time()
 
-        chat_streamer = ov_chat_engine.stream_chat(user_msg).response_gen
-        for partial_text in chat_streamer:
-            history[-1]["content"] += partial_text
-            yield history
+    def _run_generate() -> None:
+        with inference_lock:
+            chat_model.generate(**gen_kwargs)
 
-        end_time = time.time()
-
-        reply = _message_plain_text(history[-1].get("content"))
-        tokens = len(reply.split(" ")) * 4 / 3
-        processing_time = end_time - start_time
-        log.info(f"Chat model response time: {processing_time:.2f} seconds ({tokens / processing_time:.2f} tokens/s)")
+    thread = Thread(target=_run_generate)
+    start_time = time.time()
+    thread.start()
+    for token in streamer:
+        history[-1]["content"] += token
+        yield history
+    thread.join()
+    end_time = time.time()
+    reply = _message_plain_text(history[-1].get("content"))
+    tokens = len(reply.split(" ")) * 4 / 3
+    processing_time = end_time - start_time
+    log.info(f"Chat model response time: {processing_time:.2f} seconds ({tokens / processing_time:.2f} tokens/s)")
 
 
 def transcribe(audio: Tuple[int, np.ndarray], prompt: str, conversation: List[dict]) -> List[dict]:
@@ -524,7 +602,15 @@ def run(asr_model_dir: Path, asr_model_device: str, chat_model_dir: Path, chat_m
     # load tts model
     load_tts_model()
 
-    if asr_model is None or ov_llm is None or ov_embedding is None:
+    if (
+        asr_model is None
+        or chat_model is None
+        or chat_tokenizer is None
+        or embedding_model is None
+        or embedding_tokenizer is None
+        or reranker_model is None
+        or reranker_tokenizer is None
+    ):
         log.error("Required models are not loaded. Exiting...")
         return
 

--- a/ai_ref_kits/conversational_ai_chatbot/requirements.txt
+++ b/ai_ref_kits/conversational_ai_chatbot/requirements.txt
@@ -2,14 +2,13 @@
 
 openvino==2026.1.0
 openvino-tokenizers==2026.1.0.0
-optimum-intel==1.25.2
-nncf==2.18.0
+nncf==3.1.0
 
-llama-index==0.13.0
-llama-index-llms-openvino==0.5.0
-llama-index-embeddings-openvino==0.6.0
-llama-index-postprocessor-openvino-rerank==0.5.0
-# >=1.1.2 fixes SSRF redirect bypass in HTMLHeaderTextSplitter.split_text_from_url (requires langchain-core>=1.2.31).
+transformers==5.0.0
+
+# Optimum-Intel with Transformers v5 support is currently only on main (not yet on PyPI).
+optimum-intel[openvino] @ git+https://github.com/huggingface/optimum-intel.git
+
 langchain-text-splitters==1.1.2
 
 onnx==1.21.0
@@ -18,7 +17,6 @@ torch==2.8.0
 torchaudio==2.8.0
 numpy==2.2.6
 
-transformers==4.53.3
 datasets==4.0.0
 librosa==0.10.2
 pyyaml==6.0.1
@@ -44,7 +42,7 @@ g2p_en==2.1.0
 anyascii==0.3.2
 jamo==0.4.1
 gruut[de,es,fr]==2.4.0
-cached_path==1.7.3
+cached_path==1.8.10
 eng_to_ipa==0.0.2
 g2pkk==0.1.2
 inflect==7.0.0

--- a/ai_ref_kits/conversational_ai_chatbot/requirements.txt
+++ b/ai_ref_kits/conversational_ai_chatbot/requirements.txt
@@ -10,8 +10,8 @@ llama-index-embeddings-openvino==0.6.0
 llama-index-postprocessor-openvino-rerank==0.5.0
 langchain-text-splitters==0.3.11
 
-onnx==1.18.0
-onnxruntime==1.20.1
+onnx==1.21.0
+onnxruntime==1.21.0
 torch==2.8.0
 torchaudio==2.8.0
 numpy==2.2.6

--- a/ai_ref_kits/conversational_ai_chatbot/requirements.txt
+++ b/ai_ref_kits/conversational_ai_chatbot/requirements.txt
@@ -23,9 +23,12 @@ pyyaml==6.0.1
 pymupdf==1.26.3
 setuptools==81.0.0
 
-gradio==5.35.0
+gradio==6.7.0
 
-# melotts dependencies
+nltk>=3.8.1
+
+# MeloTTS: install from git with --no-deps AFTER this file (see README). MeloTTS's package metadata
+# still pins older fugashi/gruut/librosa than this kit; we keep newer pins for ASR/LLM compatibility.
 cn2an==0.5.22
 pypinyin==0.50.0
 jieba==0.42.1
@@ -40,3 +43,11 @@ anyascii==0.3.2
 jamo==0.4.1
 gruut[de,es,fr]==2.4.0
 cached_path==1.7.3
+eng_to_ipa==0.0.2
+g2pkk==0.1.2
+inflect==7.0.0
+langid==1.1.6
+loguru==0.7.2
+tensorboard==2.16.2
+txtsplit==1.0.0
+unidecode==1.3.7

--- a/ai_ref_kits/conversational_ai_chatbot/requirements.txt
+++ b/ai_ref_kits/conversational_ai_chatbot/requirements.txt
@@ -1,6 +1,7 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 
-openvino==2025.3
+openvino==2026.1.0
+openvino-tokenizers==2026.1.0.0
 optimum-intel==1.25.2
 nncf==2.18.0
 
@@ -8,7 +9,8 @@ llama-index==0.13.0
 llama-index-llms-openvino==0.5.0
 llama-index-embeddings-openvino==0.6.0
 llama-index-postprocessor-openvino-rerank==0.5.0
-langchain-text-splitters==0.3.11
+# >=1.1.2 fixes SSRF redirect bypass in HTMLHeaderTextSplitter.split_text_from_url (requires langchain-core>=1.2.31).
+langchain-text-splitters==1.1.2
 
 onnx==1.21.0
 onnxruntime==1.21.0


### PR DESCRIPTION
Transformers v5 + Optimum-Intel (remove LlamaIndex LLM blocker)
This change upgrades the conversational kit to Transformers v5 (addressing the Trainer checkpoint-loading security advisory) by removing the LlamaIndex LLM integration path. Even the latest llama-index-llms-openvino depends on llama-index-llms-huggingface, which pins transformers<5, making a Transformers v5 bump impossible without refactoring.

The kit now runs generation, embeddings, and reranking directly via Optimum-Intel OpenVINO models:

Chat: OVModelForCausalLM + AutoTokenizer.apply_chat_template() with streaming via TextIteratorStreamer.
RAG: in-memory pipeline (chunk → embed → cosine top‑k → optional rerank with OVModelForSequenceClassification), then stuffs retrieved context into the system prompt for the response.
Concurrency: retains a single global inference lock to avoid OpenVINO “Infer Request is busy” errors under Gradio’s concurrent event execution.

Gradio 6 Chatbot compatibility
The kit previously constructed gr.Chatbot with the legacy tuple layout ([[user, assistant], …]). Gradio 6 expects OpenAI-style messages ({"role": "...", "content": "..."}), which could crash UI flow. This update standardizes the initial state, reset state, streaming ASR transcription, streamed replies, and TTS prompt extraction on the OpenAI-style message format, and includes a helper that extracts plain text from either a string or Gradio’s normalized multimodal content list.

Dependency / install notes
To support the Transformers v5 upgrade, the requirements no longer include LlamaIndex LLM packages and instead rely on optimum-intel[openvino] from GitHub (until a PyPI release supports the Transformers v5 stack end-to-end).